### PR TITLE
fix: update GCS bucket lifecycle policy to preserve Terraform state

### DIFF
--- a/terraform/1-bootstrap/main.tf
+++ b/terraform/1-bootstrap/main.tf
@@ -33,10 +33,10 @@ resource "google_storage_bucket" "terraform_state" {
     enabled = true
   }
 
-  # Lifecycle management to reduce costs
+  # Lifecycle management - keep only 5 most recent versions of state files
   lifecycle_rule {
     condition {
-      age = 7
+      num_newer_versions = 5
     }
     action {
       type = "Delete"


### PR DESCRIPTION
## Summary
Fixed GCS bucket lifecycle policy to preserve Terraform state files

## Problem Solved
Previous policy deleted ALL objects after 7 days, causing state file loss

## Solution
Changed to only delete old versions (keep 5 most recent)

Fixes #1

The fix ensures Terraform state files are preserved while still managing storage costs through version cleanup.