### PR TITLE
feat: Implement dynamic scaling of nodes and platform components (fixes #2)

### DIFF
--- a/terraform/2-gke/node-pools.tf
+++ b/terraform/2-gke/node-pools.tf
@@ -51,14 +51,13 @@ resource "google_container_node_pool" "spot_pool" {
     auto_upgrade = true
   }
 
-  # Upgrade settings - allow disruption for cost savings
+  # Upgrade settings - conditional based on node count
   upgrade_settings {
-    strategy        = "SURGE"
-    max_surge       = 1
-    max_unavailable = 0
+    strategy = "SURGE"
+    # Single node: recreate strategy (max_unavailable=1, max_surge=0)
+    # Multi-node: rolling update (max_unavailable=0, max_surge=1)
+    max_surge       = var.node_count == 1 ? 0 : 1
+    max_unavailable = var.node_count == 1 ? 1 : 0
   }
 
-  lifecycle {
-    ignore_changes = [node_count]
-  }
 }

--- a/terraform/2-gke/outputs.tf
+++ b/terraform/2-gke/outputs.tf
@@ -51,6 +51,11 @@ output "node_pool_name" {
   value       = google_container_node_pool.spot_pool.name
 }
 
+output "node_count" {
+  description = "Number of nodes in the spot pool"
+  value       = var.node_count
+}
+
 # kubectl configuration command
 output "kubectl_config_command" {
   description = "Command to configure kubectl"

--- a/terraform/3-k8s-platform/main.tf
+++ b/terraform/3-k8s-platform/main.tf
@@ -6,4 +6,5 @@ locals {
     "cost-optimization" = "enabled"
     "terraform-module"  = "3-k8s-platform"
   }
+
 }

--- a/terraform/3-k8s-platform/nginx-ingress.tf
+++ b/terraform/3-k8s-platform/nginx-ingress.tf
@@ -26,11 +26,11 @@ resource "helm_release" "nginx_ingress" {
           }
         }
 
-        # Configure replica count from variable
-        replicaCount = var.nginx_ingress_replicas
+        # Configure replica count from dynamic calculation
+        replicaCount = var.platform_replicas
 
-        # Topology spread constraints for high availability
-        topologySpreadConstraints = [
+        # Topology spread constraints for high availability (conditional)
+        topologySpreadConstraints = var.platform_replicas > 1 ? [
           {
             maxSkew           = 1
             topologyKey       = "kubernetes.io/hostname"
@@ -43,7 +43,7 @@ resource "helm_release" "nginx_ingress" {
               }
             }
           }
-        ]
+        ] : []
 
         # Use ClusterIP service (Cloudflare Tunnel handles external access)
         service = {

--- a/terraform/3-k8s-platform/terraform.tfvars.example
+++ b/terraform/3-k8s-platform/terraform.tfvars.example
@@ -2,10 +2,12 @@
 enable_cloudflare_tunnel = false
 cloudflare_tunnel_token  = ""
 
+# Platform component replica configuration
+platform_replicas = 2  # Use 1 for single-node setups, 2 for HA
+
 # Routes are configured in Cloudflare Zero Trust Dashboard:
 # https://one.dash.cloudflare.com/networks/tunnels
 
-nginx_ingress_replicas = 2
 enable_storage_classes = true
 
 tf_state_bucket = "your-bucket-name"

--- a/terraform/3-k8s-platform/variables.tf
+++ b/terraform/3-k8s-platform/variables.tf
@@ -19,7 +19,7 @@ variable "platform_replicas" {
   default     = 2
   validation {
     condition     = contains([1, 2], var.platform_replicas)
-    error_message = "Platform replicas must be 1 or 2."
+    error_message = "Platform replicas must be 1 (single-node) or 2 (HA mode)."
   }
 }
 

--- a/terraform/3-k8s-platform/variables.tf
+++ b/terraform/3-k8s-platform/variables.tf
@@ -13,10 +13,14 @@ variable "cloudflare_tunnel_token" {
   sensitive   = true
 }
 
-variable "nginx_ingress_replicas" {
-  description = "Number of NGINX Ingress Controller replicas"
+variable "platform_replicas" {
+  description = "Number of replicas for platform components (NGINX Ingress, Cloudflare Tunnel)"
   type        = number
   default     = 2
+  validation {
+    condition     = contains([1, 2], var.platform_replicas)
+    error_message = "Platform replicas must be 1 or 2."
+  }
 }
 
 variable "enable_storage_classes" {


### PR DESCRIPTION
## Key changes
- Added platform_replicas variable for controlling platform component replicas
- Updated GKE node pool upgrade strategy based on node count
- Made topology spread constraints conditional on replica count
- Added Pod Disruption Budgets only for multi-replica setups
- Requires manual coordination between node_count and platform_replicas variables
- Updated README with correct two-stage scaling process

Fixes #2 